### PR TITLE
Adding friendship to students enrolled in a course

### DIFF
--- a/src/cs_auth/models.py
+++ b/src/cs_auth/models.py
@@ -240,7 +240,8 @@ class FriendshipStatus(models.StatusModel):
         ('pending', _('pending')),
         ('friend', _('friend')),
         ('acquaintance', _('acquaintance')),
-        ('unfriend', _('unfriend'))
+        ('unfriend', _('unfriend')),
+        ('colleague',_('colleague'))
     )
 
     owner = models.ForeignKey(models.User, related_name='associated')
@@ -255,11 +256,15 @@ class FriendshipStatus(models.StatusModel):
         try:
             FriendshipStatus.objects.get(owner=self.other, other=self.owner)
         except FriendshipStatus.DoesNotExist:
-            FriendshipStatus(
-                    owner=self.other,
-                    other=self.owner,
-                    status='pending').save()
-
+            friendship = FriendshipStatus(
+                                owner=self.other,
+                                other=self.owner)
+            if(self.status == "colleague"):
+                friendship.status = "colleague"
+            else:
+                friendship.status = "pending"
+            friendship.save()
+                                
 
 
 # Mokey patch the user class

--- a/src/cs_courses/models.py
+++ b/src/cs_courses/models.py
@@ -5,7 +5,7 @@ from autoslug import AutoSlugField
 from wagtail.wagtailcore.fields import RichTextField
 from codeschool import models
 from cs_activities.models import Activity
-
+from cs_auth.models import FriendshipStatus as FriendShip
 
 #
 # Main model classes
@@ -59,6 +59,22 @@ class Course(models.DateFramedModel, models.TimeStampedModel):
     current_lesson_start = models.DateField(blank=True, null=True)
     is_active = models.BooleanField(_('is active'), default=False)
 
+    def save(self, *args, **kwds):
+        super().save(*args,**kwds)
+        for student in self.students.values():
+            for colleague in self.students.values():
+                if(student["id"] != colleague["id"]):
+                    obj_student = models.User(**student)
+                    obj_colleague = models.User(**colleague)
+                    try:
+                       FriendShip.objects.get(owner=obj_student,
+                                              other=obj_colleague) 
+                    except FriendShip.DoesNotExist:
+                        FriendShip(owner=obj_student,
+                                   other=obj_colleague,
+                                   status="colleague").save()
+                                
+        
     # Managers
     @property
     def past_activities(self):


### PR DESCRIPTION
Adding colleague status at Friedship. Also, case status is
colleague the other direction friendship also is colleague.
After saving a course, all students that are not friends
will have a friendship status colleague.

Signed-off-by: Gustavo Coelho <gutorc@hotmail.com>